### PR TITLE
Add PyPI publishing workflow and docs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,13 +5,13 @@ on:
     types: [published]
 
 permissions:
+  contents: read
   id-token: write
 
 jobs:
-  publish:
-    name: Build and publish to PyPI
+  build:
+    name: Build and verify package
     runs-on: ubuntu-latest
-    environment: pypi
 
     steps:
       - uses: actions/checkout@v4
@@ -21,10 +21,50 @@ jobs:
           python-version: "3.12"
 
       - name: Install build dependencies
-        run: pip install build
+        run: pip install build twine
 
       - name: Build package
         run: python -m build
+
+      - name: Verify package metadata
+        run: twine check dist/*
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish-testpypi:
+    name: Publish to TestPyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment: testpypi
+
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+  publish-pypi:
+    name: Publish to PyPI
+    needs: publish-testpypi
+    runs-on: ubuntu-latest
+    environment: pypi
+
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -10,18 +10,28 @@ Releases are automatically published to PyPI when you create a GitHub release.
 
 2. Create a PyPI project for `aws-assume` by doing a manual upload first (see [Manual Publishing](#manual-publishing) below), or reserve the name.
 
-3. Configure Trusted Publishing on PyPI:
-   - Go to your project on PyPI > **Settings** > **Publishing**
+3. Configure Trusted Publishing on **TestPyPI**:
+   - Go to [test.pypi.org](https://test.pypi.org) > your project > **Settings** > **Publishing**
+   - Add a new **GitHub** publisher:
+     - **Owner**: `Specter099`
+     - **Repository**: `aws-assume`
+     - **Workflow name**: `publish.yml`
+     - **Environment name**: `testpypi`
+
+4. Configure Trusted Publishing on **PyPI**:
+   - Go to [pypi.org](https://pypi.org) > your project > **Settings** > **Publishing**
    - Add a new **GitHub** publisher:
      - **Owner**: `Specter099`
      - **Repository**: `aws-assume`
      - **Workflow name**: `publish.yml`
      - **Environment name**: `pypi`
 
-4. Create a GitHub environment:
+5. Create GitHub environments:
    - Go to your repo **Settings** > **Environments**
+   - Create an environment named `testpypi`
    - Create an environment named `pypi`
-   - Optionally add a required reviewer for extra safety
+     - Add a required reviewer for production safety
+     - Optionally restrict deployment branches to tags only
 
 ### Creating a release
 
@@ -64,7 +74,8 @@ If you need to publish manually (e.g., for the first upload):
 
 ### Testing with TestPyPI
 
-To test the publishing process without affecting the real package index:
+TestPyPI is published automatically as part of the release workflow (before PyPI).
+To test manually without affecting the real package index:
 
 1. Create an account at [test.pypi.org](https://test.pypi.org/account/register/).
 


### PR DESCRIPTION
## Summary
- Adds GitHub Actions workflow (`.github/workflows/publish.yml`) that automatically publishes to PyPI on GitHub release creation using Trusted Publishing
- Adds `PUBLISHING.md` documenting one-time setup, automated and manual publishing, TestPyPI testing, and versioning conventions

## Test plan
- [ ] Verify workflow syntax is valid via GitHub Actions
- [ ] Configure Trusted Publishing on PyPI per PUBLISHING.md instructions
- [ ] Create a GitHub environment named `pypi`
- [ ] Test with a release to confirm end-to-end publishing works

🤖 Generated with [Claude Code](https://claude.com/claude-code)