### PR TITLE
fix: remove TestPyPI step from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,27 +35,9 @@ jobs:
           name: dist
           path: dist/
 
-  publish-testpypi:
-    name: Publish to TestPyPI
-    needs: build
-    runs-on: ubuntu-latest
-    environment: testpypi
-
-    steps:
-      - name: Download build artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: dist
-          path: dist/
-
-      - name: Publish to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/
-
   publish-pypi:
     name: Publish to PyPI
-    needs: publish-testpypi
+    needs: build
     runs-on: ubuntu-latest
     environment: pypi
 


### PR DESCRIPTION
## Summary
- Removes the TestPyPI publish step since trusted publishing isn't configured there
- Publishes directly to PyPI after the build/verify stage
- Unblocks the v0.1.0 release

🤖 Generated with [Claude Code](https://claude.com/claude-code)