### PR TITLE
chore: rename package to aws-assume-cli and update description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # aws-assume
 
-Slick CLI for AWS SSO credential management across multiple accounts and roles.
+Simple CLI for AWS SSO credential management across multiple accounts and roles.
 
 ## Installation
 
 ```bash
-pip install aws-assume
+pip install aws-assume-cli
 ```
 
 ## Usage

--- a/aws_assume/cli.py
+++ b/aws_assume/cli.py
@@ -56,7 +56,7 @@ def _print_info(msg: str) -> None:
 @click.pass_context
 def cli(ctx, profile, output_eval, env_file, write_creds, creds_profile,
         output_json, duration, no_auto_login, list_only):
-    """Slick CLI for AWS SSO credential management across multiple accounts and roles.
+    """Simple CLI for AWS SSO credential management across multiple accounts and roles.
 
     \b
     Examples:

--- a/cli.py
+++ b/cli.py
@@ -50,7 +50,7 @@ def _print_info(msg: str) -> None:
 @click.pass_context
 def cli(ctx, profile, output_eval, env_file, write_creds, creds_profile,
         output_json, duration, no_auto_login, list_only):
-    """Slick CLI for AWS SSO credential management across multiple accounts and roles.
+    """Simple CLI for AWS SSO credential management across multiple accounts and roles.
 
     \b
     Examples:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,9 @@ requires = ["setuptools>=68", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "aws-assume"
+name = "aws-assume-cli"
 version = "0.1.0"
-description = "Slick CLI for AWS SSO credential management across multiple accounts and roles"
+description = "Simple CLI for AWS SSO credential management across multiple accounts and roles"
 readme = "README.md"
 license = { text = "MIT" }
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Rename PyPI package from `aws-assume` to `aws-assume-cli` (original name is taken)
- Update description from "Slick" to "Simple" in all files
- Update install command in README

🤖 Generated with [Claude Code](https://claude.com/claude-code)