### PR TITLE
chore: add badges, GitHub Release job, and pin Actions to SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.12"
 
@@ -35,9 +35,9 @@ jobs:
         python-version: ["3.10", "3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,7 @@ on:
     types: [published]
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.12"
 
@@ -30,7 +30,7 @@ jobs:
         run: twine check dist/*
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: dist
           path: dist/
@@ -43,10 +43,27 @@ jobs:
 
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: dist
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+
+  github-release:
+    name: Upload release assets
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: dist
+          path: dist/
+
+      - name: Attach artifacts to GitHub Release
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
+        with:
+          files: dist/*

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10
         with:
           stale-issue-message: >
             This issue has been automatically marked as stale because it has not

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # aws-assume
 
+[![CI](https://github.com/Specter099/aws-assume/actions/workflows/ci.yml/badge.svg)](https://github.com/Specter099/aws-assume/actions/workflows/ci.yml)
+[![PyPI](https://img.shields.io/pypi/v/aws-assume-cli)](https://pypi.org/project/aws-assume-cli/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
 Simple CLI for AWS SSO credential management across multiple accounts and roles.
 
 ## Installation


### PR DESCRIPTION
## Summary

- Add CI, PyPI, and license badges to README
- Add `github-release` job to publish workflow that attaches build artifacts to GitHub Releases using `softprops/action-gh-release`
- Pin all third-party GitHub Actions to commit SHAs (with version comments) to mitigate supply chain risk
- Upgrade `contents` permission in publish workflow from `read` to `write` for release asset uploads

### Actions pinned

| Action | Version | SHA |
|--------|---------|-----|
| `actions/checkout` | v6 | `de0fac2e` |
| `actions/setup-python` | v6 | `a309ff8b` |
| `actions/upload-artifact` | v6 | `b7c566a7` |
| `actions/download-artifact` | v7 | `37930b1c` |
| `actions/stale` | v10 | `b5d41d4e` |
| `pypa/gh-action-pypi-publish` | v1.13.0 | `ed0c5393` |
| `softprops/action-gh-release` | v2 | `a06a81a0` |

## Test plan

- [x] CI passes (lint + tests)
- [ ] Verify badges render on README
- [ ] Verify release workflow attaches assets on next tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)