### PR TITLE
chore: update project URLs to match renamed repo

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,9 +34,9 @@ dependencies = [
 aws-assume = "aws_assume.cli:main"
 
 [project.urls]
-Homepage = "https://github.com/brianjbeach/aws-assume"
-Repository = "https://github.com/brianjbeach/aws-assume"
-Issues = "https://github.com/brianjbeach/aws-assume"
+Homepage = "https://github.com/Specter099/aws-assume-cli"
+Repository = "https://github.com/Specter099/aws-assume-cli"
+Issues = "https://github.com/Specter099/aws-assume-cli/issues"
 
 [tool.setuptools.packages.find]
 where = ["."]


### PR DESCRIPTION
## Summary

- Renamed GitHub repo from `aws-assume` to `aws-assume-cli` to align with the PyPI package name
- Updated `[project.urls]` in `pyproject.toml` to point to the new repo URL
- Also fixed the Issues URL to use the proper `/issues` suffix

🤖 Generated with [Claude Code](https://claude.com/claude-code)