### PR TITLE
chore: bump version to 0.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aws-assume-cli"
-version = "0.1.0"
+version = "0.1.1"
 description = "Simple CLI for AWS SSO credential management across multiple accounts and roles"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
## Summary

- Bump version to `0.1.1`
- Patch release to publish updated README and project URLs to PyPI following the repo rename from `aws-assume` to `aws-assume-cli`

🤖 Generated with [Claude Code](https://claude.com/claude-code)